### PR TITLE
Scoring updates

### DIFF
--- a/metasync/set_weights_on_metagraph.py
+++ b/metasync/set_weights_on_metagraph.py
@@ -20,6 +20,57 @@ from fiber.chain.chain_utils import query_substrate
 VERSION_KEY = 69420  # Doesn't matter too much in chutes' case
 logger = get_logger(__name__)
 
+NORMALIZED_COMPUTE_QUERY = """
+WITH computation_rates AS (
+    SELECT
+        chute_id,
+        percentile_cont(0.5) WITHIN GROUP (ORDER BY extract(epoch from completed_at - started_at) / (metrics->>'steps')::float) as median_step_time,
+        percentile_cont(0.5) WITHIN GROUP (ORDER BY extract(epoch from completed_at - started_at) / (metrics->>'tokens')::float) as median_token_time
+    FROM invocations
+    WHERE (metrics->>'steps' IS NOT NULL and (metrics->>'steps')::float > 0)
+       OR (metrics->>'tokens' IS NOT NULL and (metrics->>'tokens')::float > 0)
+    GROUP BY chute_id
+)
+SELECT
+    i.miner_hotkey,
+    sum(
+        i.bounty +
+        i.compute_multiplier *
+        CASE
+            WHEN i.metrics->>'steps' IS NOT NULL
+                AND r.median_step_time IS NOT NULL
+                AND EXTRACT(EPOCH FROM (i.completed_at - i.started_at)) > ((i.metrics->>'steps')::float * r.median_step_time)
+            THEN (i.metrics->>'steps')::float * r.median_step_time
+            WHEN i.metrics->>'tokens' IS NOT NULL
+                AND r.median_token_time IS NOT NULL
+                AND EXTRACT(EPOCH FROM (i.completed_at - i.started_at)) > ((i.metrics->>'tokens')::float * r.median_token_time)
+            THEN (i.metrics->>'tokens')::float * r.median_token_time
+            ELSE EXTRACT(EPOCH FROM (i.completed_at - i.started_at))
+        END
+    ) AS compute_units
+FROM invocations i
+LEFT JOIN computation_rates r ON i.chute_id = r.chute_id
+WHERE i.started_at > NOW() - INTERVAL '{interval}'
+AND i.error_message IS NULL
+AND i.miner_uid > 0
+GROUP BY i.miner_hotkey
+HAVING SUM(
+    i.bounty +
+    i.compute_multiplier *
+    CASE
+        WHEN i.metrics->>'steps' IS NOT NULL
+            AND r.median_step_time IS NOT NULL
+            AND EXTRACT(EPOCH FROM (i.completed_at - i.started_at)) > ((i.metrics->>'steps')::float * r.median_step_time)
+        THEN (i.metrics->>'steps')::float * r.median_step_time
+        WHEN i.metrics->>'tokens' IS NOT NULL
+            AND r.median_token_time IS NOT NULL
+            AND EXTRACT(EPOCH FROM (i.completed_at - i.started_at)) > ((i.metrics->>'tokens')::float * r.median_token_time)
+        THEN (i.metrics->>'tokens')::float * r.median_token_time
+        ELSE EXTRACT(EPOCH FROM (i.completed_at - i.started_at))
+    END
+) > 0 ORDER BY compute_units DESC;
+"""
+
 
 async def _get_validator_node_id(
     substrate: SubstrateInterface, netuid: int, ss58_address: str
@@ -44,20 +95,7 @@ async def _get_weights_to_set(
     """
 
     interval = "7 days"
-
-    query = text(
-        f"""
-        SELECT
-            i.miner_hotkey,
-            sum(i.bounty + i.compute_multiplier * EXTRACT(EPOCH FROM (i.completed_at - i.started_at))) AS compute_units
-        FROM invocations i
-        WHERE i.started_at > NOW() - INTERVAL '{interval}'
-        AND i.error_message IS NULL
-        AND miner_uid > 0
-        GROUP BY i.miner_hotkey
-        HAVING SUM(i.bounty + i.compute_multiplier * EXTRACT(EPOCH FROM (i.completed_at - i.started_at))) > 0
-        """
-    )
+    query = text(NORMALIZED_COMPUTE_QUERY.format(interval=interval))
 
     miner_compute_units = {}
     async with get_session() as session:

--- a/metasync/set_weights_on_metagraph.py
+++ b/metasync/set_weights_on_metagraph.py
@@ -64,6 +64,7 @@ LEFT JOIN computation_rates r ON i.chute_id = r.chute_id
 WHERE i.started_at > NOW() - INTERVAL '{interval}'
 AND i.error_message IS NULL
 AND i.miner_uid > 0
+AND i.completed_at IS NOT NULL
 GROUP BY i.miner_hotkey
 ORDER BY compute_units DESC;
 """


### PR DESCRIPTION
- Use median tokens per second per chute normalized compute time for vllm to normalize compute time
- Use median steps per second per chute normalized compute time for diffusion
- Use additional metrics in score calculation:
  - 45% weight on total amount of compute time (compute muliplier * total time)
  - 25% on total number of invocations (meaning they handle a lot of requests)
  - 20% on unique chute count, meaning they aren't just running a single/small number of chutes
  - 10% on bounty count, bounty values help the compute time, this rewards being good at getting bounties, regardless of compute time