### PR TITLE
Updated scoring to reward compute efficiency

### DIFF
--- a/metasync/constants.py
+++ b/metasync/constants.py
@@ -1,11 +1,16 @@
 # Proportion of weights to assign to each metric.
 FEATURE_WEIGHTS = {
-    "compute_units": 0.45,  # Total amount of compute time (compute muliplier * total time).
-    "invocation_count": 0.25,  # Total number of invocations.
-    "unique_chute_count": 0.20,  # Number of unique chutes over the scoring period.
-    "bounty_count": 0.1,  # Number of bounties received (not bounty values, just counts).
+    "compute_units": 0.42,  # Total amount of compute time (compute muliplier * total time).
+    "invocation_count": 0.2,  # Total number of invocations.
+    "unique_chute_count": 0.2,  # Average instantaneous unique chutes over the scoring period.
+    "utilization": 0.1,  # Utilization rate based on active compute time for each instance.
+    "bounty_count": 0.08,  # Number of bounties received (not bounty values, just counts).
 }
+# Time slice to calculate the incentives from.
 SCORING_INTERVAL = "7 days"
+# Minimum utilization ratio of instances to be considered for scoring (aka, are you providing real utility with your nodes or just idle compute)
+MINIMUM_UTILIZATION = 0.3
+# Query to fetch raw metrics for compute_units, invocation_count, and bounty_count.
 NORMALIZED_COMPUTE_QUERY = """
 WITH computation_rates AS (
     SELECT
@@ -20,7 +25,6 @@ WITH computation_rates AS (
 SELECT
     i.miner_hotkey,
     COUNT(*) as invocation_count,
-    COUNT(DISTINCT(i.chute_id)) AS unique_chute_count,
     COUNT(CASE WHEN i.bounty > 0 THEN 1 END) AS bounty_count,
     sum(
         i.bounty +
@@ -44,4 +48,86 @@ AND i.miner_uid > 0
 AND i.completed_at IS NOT NULL
 GROUP BY i.miner_hotkey
 ORDER BY compute_units DESC;
+"""
+# Query to calculate the average number of unique chutes active at any single point in time, i.e. unique_count_count.
+UNIQUE_CHUTE_AVERAGE_QUERY = """
+WITH time_series AS (
+  SELECT
+    generate_series(
+      date_trunc('hour', now() - INTERVAL '{interval}'),
+      date_trunc('hour', now()),
+      INTERVAL '10 minutes'
+    ) AS time_point
+),
+chute_timeframes AS (
+  SELECT
+    chute_id,
+    miner_hotkey,
+    MIN(started_at) AS first_invocation,
+    MAX(started_at) AS last_invocation
+  FROM invocations
+  WHERE
+    started_at >= now() - INTERVAL '{interval}'
+    AND error_message IS NULL
+    AND completed_at IS NOT NULL
+  GROUP BY chute_id, miner_hotkey
+),
+ten_minute_active_chutes AS (
+  SELECT
+    t.time_point,
+    ct.miner_hotkey,
+    COUNT(DISTINCT ct.chute_id) AS active_chutes
+  FROM time_series t
+  LEFT JOIN chute_timeframes ct ON
+    t.time_point >= ct.first_invocation AND
+    t.time_point <= ct.last_invocation
+  GROUP BY t.time_point, ct.miner_hotkey
+)
+SELECT
+  miner_hotkey,
+  AVG(active_chutes)::integer AS avg_active_chutes
+FROM ten_minute_active_chutes
+GROUP BY miner_hotkey
+ORDER BY avg_active_chutes DESC;
+"""
+# Query to calculate the compute-time weighted utilization rate of your instances.
+UTILIZATION_QUERY = """
+WITH instance_metrics AS (
+  SELECT
+    miner_hotkey,
+    instance_id,
+    MAX(completed_at) - MIN(started_at) as instance_active_time,
+    SUM(completed_at - started_at) AS instance_processing_time
+  FROM invocations
+  WHERE started_at >= now() - INTERVAL '{interval}'
+  AND error_message IS NULL AND completed_at IS NOT NULL
+  GROUP BY miner_hotkey, instance_id
+),
+instance_utilization_ratios AS (
+  SELECT
+    miner_hotkey,
+    instance_id,
+    instance_active_time,
+    instance_processing_time,
+    EXTRACT(EPOCH FROM instance_processing_time) AS instance_processing_seconds,
+    CASE
+      WHEN EXTRACT(EPOCH FROM instance_active_time) > 0
+      THEN LEAST(
+        (EXTRACT(EPOCH FROM instance_processing_time) /
+         EXTRACT(EPOCH FROM instance_active_time)),
+        1.00
+      )
+      ELSE 0
+    END AS instance_utilization_ratio
+  FROM instance_metrics
+)
+SELECT
+  miner_hotkey,
+  ROUND(
+    SUM(instance_utilization_ratio * instance_processing_seconds) /
+    NULLIF(SUM(instance_processing_seconds), 0)
+  ::numeric, 2) AS utilization_ratio
+FROM instance_utilization_ratios
+GROUP BY miner_hotkey
+ORDER BY utilization_ratio DESC
 """


### PR DESCRIPTION
### Overview
Currently, chutes.ai has an oversupply of compute. This PR is a first attempt to help address that oversupply issue, by incentivizing miners to scale according to actual demands on the platform.
- New "utilization" score which uses a compute-time-weighted ratio of used compute time vs "online" time for each instance of each miner.
- Require a minimum threshold of utilization to be considered for scoring.

Additionally, the unique_chute_count score will now be the average number of unique chutes that are active and verified having at least one successful response at instantaneous time points every 10 minutes across the scoring period, e.g. if on average you have 10 unique chutes running at all times, but those 10 chutes change regularly, your average unique chute count will be 10 (vs counting the total number of unique chutes you ever ran).

The intention of the change is to promote two things:
1. reduce the sell pressure that is forced as a result of miners paying for unused/excess compute
2. incentivize scale only as a function of the growth of the platform, which in theory incentivizes people to market use of existing chutes that boost utilization or add new chutes that are utilized a lot

### Analysis
Based on the current proposed utilization ratio, the invocation rates of the chutes currently on the platform, and the corresponding miner inventory, the following GPUs would stop receiving incentive at all, and would therefore likely be removed from the platform and that sell pressure to maintain that unused inventory would dissipate.
```sql
chutes=> select name, count(*) from nodes where miner_hotkey in (select miner_hotkey from (WITH instance_metrics AS (
  SELECT
    miner_hotkey,
    instance_id,
    MAX(completed_at) - MIN(started_at) as instance_active_time,
    SUM(completed_at - started_at) AS instance_processing_time
  FROM invocations
  WHERE started_at >= now() - INTERVAL '7 days'
  AND error_message IS NULL AND completed_at IS NOT NULL
  GROUP BY miner_hotkey, instance_id
),
instance_busy_ratios AS (
  SELECT
    miner_hotkey,
    instance_id,
    instance_active_time,
    instance_processing_time,
    EXTRACT(EPOCH FROM instance_processing_time) AS instance_processing_seconds,
    CASE
      WHEN EXTRACT(EPOCH FROM instance_active_time) > 0
      THEN LEAST(
        (EXTRACT(EPOCH FROM instance_processing_time) /
         EXTRACT(EPOCH FROM instance_active_time)),
        1.00
      )
      ELSE 0
    END AS instance_busy_ratio
  FROM instance_metrics
)
SELECT
  miner_hotkey,
  SUM(EXTRACT(EPOCH FROM instance_active_time)) AS total_active_seconds,
  SUM(instance_processing_seconds) AS total_processing_seconds,
  ROUND(
    SUM(instance_busy_ratio * instance_processing_seconds) /
    NULLIF(SUM(instance_processing_seconds), 0)
  ::numeric, 2) AS weighted_avg_busy_ratio
FROM instance_busy_ratios
GROUP BY miner_hotkey
ORDER BY weighted_avg_busy_ratio DESC) where weighted_avg_busy_ratio < 0.3) group by name order by count desc;
              name              | count
--------------------------------+-------
 NVIDIA GeForce RTX 4090        |   227
 NVIDIA A100-SXM4-80GB          |   206
 NVIDIA RTX A6000               |   179
 NVIDIA A100 80GB PCIe          |    67
 NVIDIA L40                     |    37
 NVIDIA H100 PCIe               |    35
 NVIDIA L40S                    |    33
 NVIDIA H100 80GB HBM3          |    31
 NVIDIA GeForce RTX 3090        |    26
 NVIDIA RTX A4000               |    19
 NVIDIA A40                     |    11
 NVIDIA RTX 4000 Ada Generation |    10
 NVIDIA A100-SXM4-40GB          |     7
 NVIDIA RTX 6000 Ada Generation |     3
 NVIDIA A10                     |     2
 NVIDIA H200                    |     1
 NVIDIA H100 NVL                |     1
 NVIDIA RTX A5000               |     1
 NVIDIA A100-PCIE-40GB          |     1
(19 rows)
```

Additionally, we can see that the vast majority of chutes would still be operational by the miners that remain in contention with a utilization ratio of > 0.3:
```sql
chutes=> select count(distinct(chute_id)) from instances where verified is true and miner_hotkey in (...);
 count
-------
    52
(1 row)
```