### PR TITLE
Cap the number of instances for underutilized chutes.

### DIFF
--- a/api/api_key/router.py
+++ b/api/api_key/router.py
@@ -97,8 +97,8 @@ async def create_api_key(
     """
     Create a new API key.
     """
-    api_key, one_time_secret = APIKey.create(current_user.user_id, key_args)
     try:
+        api_key, one_time_secret = APIKey.create(current_user.user_id, key_args)
         db.add(api_key)
         await db.commit()
         await db.refresh(api_key)

--- a/api/bounty/router.py
+++ b/api/bounty/router.py
@@ -41,6 +41,6 @@ async def list_bounties(
         )
         results = await session.execute(query)
         bounties = []
-        for chute, bounty, last_increased_at in results.all():
+        for chute, bounty, last_increased_at in results.unique().all():
             bounties.append(Bounty(bounty=bounty, last_increased_at=last_increased_at, chute=chute))
         return bounties

--- a/api/chute/router.py
+++ b/api/chute/router.py
@@ -273,7 +273,7 @@ async def get_chute_utilization():
             )
             SELECT * FROM chute_utilization
             JOIN chute_details
-            ON instance_counts.chute_id = chute_utilization.chute_id;
+            ON chute_details.chute_id = chute_utilization.chute_id;
         """)
         results = await session.execute(query)
         rows = results.mappings().all()

--- a/api/chute/schemas.py
+++ b/api/chute/schemas.py
@@ -183,6 +183,7 @@ class Chute(Base):
     image = relationship("Image", back_populates="chutes", lazy="joined")
     user = relationship("User", back_populates="chutes", lazy="joined")
     logo = relationship("Logo", back_populates="chutes", lazy="joined")
+    rolling_update = relationship("RollingUpdate", back_populates="chute", lazy="joined")
     instances = relationship(
         "Instance", back_populates="chute", lazy="select", cascade="all, delete-orphan"
     )
@@ -304,3 +305,14 @@ class ChuteHistory(Base):
     created_at = Column(DateTime, server_default=func.now())
     updated_at = Column(DateTime, server_default=func.now())
     deleted_at = Column(DateTime, server_default=func.now())
+
+
+class RollingUpdate(Base):
+    __tablename__ = "rolling_updates"
+    chute_id = Column(String, ForeignKey("chutes.chute_id", ondelete="CASCADE"), nullable=False)
+    old_version = Column(String, nullable=False)
+    new_version = Column(String, nullable=False)
+    started_at = Column(DateTime, server_default=func.now())
+    permitted = Column(JSONB, nullable=False)
+
+    chute = relationship("Chute", back_populates="instances")

--- a/api/chute/schemas.py
+++ b/api/chute/schemas.py
@@ -309,10 +309,12 @@ class ChuteHistory(Base):
 
 class RollingUpdate(Base):
     __tablename__ = "rolling_updates"
-    chute_id = Column(String, ForeignKey("chutes.chute_id", ondelete="CASCADE"), nullable=False)
+    chute_id = Column(
+        String, ForeignKey("chutes.chute_id", ondelete="CASCADE"), nullable=False, primary_key=True
+    )
     old_version = Column(String, nullable=False)
     new_version = Column(String, nullable=False)
     started_at = Column(DateTime, server_default=func.now())
     permitted = Column(JSONB, nullable=False)
 
-    chute = relationship("Chute", back_populates="instances")
+    chute = relationship("Chute", back_populates="rolling_update")

--- a/api/chute/util.py
+++ b/api/chute/util.py
@@ -238,7 +238,7 @@ async def get_chute_by_id_or_name(chute_id_or_name, db, current_user, load_insta
     ).order_by((Chute.user_id == chute_user).desc())
 
     result = await db.execute(query)
-    return result.scalar_one_or_none()
+    return result.unique().scalar_one_or_none()
 
 
 @alru_cache(maxsize=100)

--- a/api/constants.py
+++ b/api/constants.py
@@ -25,3 +25,9 @@ LLM_PRICE_MULT_PER_MILLION = 0.2
 # counts, so we can't really have a fixed "per image" pricing, just a price
 # that varies based on the node selector and the number of steps requested.
 DIFFUSION_PRICE_MULT_PER_STEP = 0.005
+
+# Minimum utilization of a chute before additional instances can be added.
+EXPANSION_UTILIZATION_THRESHOLD = 0.05
+
+# Cap on number of instances for an underutilized chute.
+UNDERUTILIZED_CAP = 7

--- a/api/graval_worker.py
+++ b/api/graval_worker.py
@@ -27,11 +27,12 @@ from api.util import (
 )
 from api.database import get_session
 from api.node.schemas import Node
+from api.chute.schemas import Chute, RollingUpdate
 from api.instance.schemas import Instance
 from api.fs_challenge.schemas import FSChallenge
 from sqlalchemy import update, func, and_, not_
 from sqlalchemy.future import select
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import joinedload, selectinload
 from sqlalchemy.ext.asyncio import AsyncSession
 from taskiq_redis import ListQueueBroker, RedisAsyncResultBackend
 import api.database.orms  # noqa
@@ -718,3 +719,126 @@ async def verify_instance(instance_id: str):
         except Exception as exc:
             logger.warning(f"Error broadcasting instance event: {exc}")
         await settings.redis_client.delete(f"verify:lock:{instance_id}")
+
+
+@broker.task
+async def handle_rolling_update(chute_id: str, version: str):
+    """
+    Handle a rolling update event.
+    """
+    logger.info(f"Received rolling update task for {chute_id=}")
+    async with get_session() as session:
+        chute = (
+            (
+                await session.execute(
+                    select(Chute)
+                    .where(Chute.chute_id == chute_id)
+                    .options(selectinload(Chute.instances))
+                )
+            )
+            .unique()
+            .scalar_one_or_none()
+        )
+        if not chute:
+            logger.warning(f"Chute no longer found? {chute_id=}")
+            return
+        if not chute.instances:
+            logger.info(f"No instances to update? {chute_id=}")
+            return
+
+    # Iterate through instances slowly to avoid crashing the entire chute.
+    logger.info(
+        f"Triggering update for {len(chute.instances)} instances of {chute.chute_id=} {chute.name=}"
+    )
+    for inst in chute.instances:
+        # Make sure this rolling update is still valid, and the instance still exists.
+        async with get_session() as session:
+            instance = (
+                (
+                    await session.execute(
+                        select(Instance).where(Instance.instance_id == inst.instance_id)
+                    )
+                )
+                .unique()
+                .scalar_one_or_none()
+            )
+            rolling_update = (
+                (
+                    await session.execute(
+                        select(RollingUpdate).where(RollingUpdate.chute_id == chute_id)
+                    )
+                )
+                .unique()
+                .scalar_one_or_none()
+            )
+            if not instance:
+                logger.warning(
+                    f"Instance {inst.instance_id} no longer exists, skipping rolling update of {chute_id=} {version=}"
+                )
+                continue
+            if not rolling_update or rolling_update.new_version != version:
+                logger.warning(f"Rolling update is now defunct {chute_id=} {version=}")
+                return
+
+        # Send the event.
+        try:
+            event_data = {
+                "reason": "rolling_update",
+                "data": {
+                    "instance_id": instance.instance_id,
+                    "miner_hotkey": instance.miner_hotkey,
+                    "old_version": rolling_update.old_version,
+                    "new_version": rolling_update.new_version,
+                },
+                "filter_recipients": [instance.miner_hotkey],
+            }
+            await settings.redis_client.publish("miner_broadcast", json.dumps(event_data).decode())
+        except Exception:
+            # Allow exceptions here since the miner can also check.
+            logger.warning(
+                f"Error notifying miner {instance.miner_hotkey} about rolling update of {instance.instance_id=} for {chute.name=}"
+            )
+
+        # Wait before notifying the next miner.
+        await asyncio.sleep(180)
+
+    # Once finished, clean up all instances still bound to the old version.
+    async with get_session() as session:
+        rolling_update = (
+            (await session.execute(select(RollingUpdate).where(RollingUpdate.chute_id == chute_id)))
+            .unique()
+            .scalar_one_or_none()
+        )
+        if not rolling_update or rolling_update.new_version != version:
+            return
+        chute = (
+            (
+                await session.execute(
+                    select(Chute)
+                    .where(Chute.chute_id == chute_id)
+                    .options(selectinload(Chute.instances))
+                )
+            )
+            .unique()
+            .scalar_one_or_none()
+        )
+        if chute:
+            for instance in chute.instances:
+                if instance.version != version:
+                    await session.delete(instance)
+                    event_data = {
+                        "reason": "instance_deleted",
+                        "message": f"Instance {instance.instance_id} of miner {instance.miner_hotkey} still bound to old version, deleting...",
+                        "data": {
+                            "chute_id": instance.chute_id,
+                            "instance_id": instance.instance_id,
+                            "miner_hotkey": instance.miner_hotkey,
+                        },
+                        "filter_recipients": [instance.miner_hotkey],
+                    }
+                    asyncio.create_task(
+                        settings.redis_client.publish(
+                            "miner_broadcast", json.dumps(event_data).decode()
+                        )
+                    )
+        await session.delete(rolling_update)

--- a/api/instance/router.py
+++ b/api/instance/router.py
@@ -51,7 +51,7 @@ async def create_instance(
         chute.rolling_update.permitted[hotkey] -= 1
 
     # Limit underutilized chutes.
-    lock_id = f"instance_lock:{chute_id}"
+    lock_id = uuid.uuid5(uuid.NAMESPACE_OID, f"instance_lock:{chute_id}").int & 0x7FFFFFFFFFFFFFFF
     try:
         await db.execute(text("SET lock_timeout = '30s'"))
         await db.execute(text("SELECT pg_advisory_lock(:lock_id)"), {"lock_id": lock_id})

--- a/api/instance/router.py
+++ b/api/instance/router.py
@@ -33,7 +33,11 @@ async def create_instance(
     hotkey: str | None = Header(None, alias=HOTKEY_HEADER),
     _: User = Depends(get_current_user(raise_not_found=False, registered_to=settings.netuid)),
 ):
-    chute = (await db.execute(select(Chute).where(Chute.chute_id == chute_id))).scalar_one_or_none()
+    chute = (
+        (await db.execute(select(Chute).where(Chute.chute_id == chute_id)))
+        .unique()
+        .scalar_one_or_none()
+    )
     if not chute:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/api/instance/router.py
+++ b/api/instance/router.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.exc import IntegrityError
 from api.database import get_db_session, generate_uuid
 from api.config import settings
-from api.constants import HOTKEY_HEADER
+from api.constants import HOTKEY_HEADER, EXPANSION_UTILIZATION_THRESHOLD, UNDERUTILIZED_CAP
 from api.node.util import get_node_by_id
 from api.chute.schemas import Chute
 from api.instance.schemas import InstanceArgs, Instance, instance_nodes, ActivateArgs
@@ -40,73 +40,101 @@ async def create_instance(
             detail=f"Chute {chute_id} not found",
         )
 
-    # Load the miner.
-    miner = await get_miner_by_hotkey(hotkey, db)
-    if not miner:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=f"Did not find miner with {hotkey=}",
-        )
-
-    # Validate the hostname.
-    if not await is_valid_host(instance_args.host):
-        logger.warning(
-            f"INSTANCEFAIL: Attempt to post bad host: {instance_args.host} from {hotkey=}"
-        )
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid instance host: {instance_args.host}",
-        )
-
-    # Instantiate the instance.
-    instance = Instance(
-        instance_id=generate_uuid(),
-        host=instance_args.host,
-        port=instance_args.port,
-        chute_id=chute_id,
-        miner_uid=miner.node_id,
-        miner_hotkey=hotkey,
-        miner_coldkey=miner.coldkey,
-        region="n/a",
-        active=False,
-        verified=False,
-        chutes_version=chute.chutes_version,
-    )
-    db.add(instance)
-
-    # Verify the GPUs are suitable.
-    gpu_count = chute.node_selector.get("gpu_count", 1)
-    if len(instance_args.node_ids) != gpu_count:
-        logger.warning(
-            f"INSTANCEFAIL: Attempt to post incorrect GPU count: {len(instance_args.node_ids)} vs {gpu_count} from {hotkey=}"
-        )
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Chute {chute_id} requires exactly {gpu_count} GPUs.",
-        )
-    gpu_type = None
-    for node_id in instance_args.node_ids:
-        node = await get_node_by_id(node_id, db, hotkey)
-        if not node:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Node {node_id} not found",
+    # Limit underutilized chutes.
+    lock_id = f"instance_lock:{chute_id}"
+    try:
+        await db.execute(text("SET lock_timeout = '30s'"))
+        await db.execute(text("SELECT pg_advisory_lock(:lock_id)"), {"lock_id": lock_id})
+        query = text("SELECT * FROM chute_utilization WHERE chute_id = :chute_id")
+        results = await db.execute(query, {"chute_id": chute_id})
+        utilization = results.mappings().first()
+        if (
+            utilization
+            and utilization["avg_busy_ratio"] < EXPANSION_UTILIZATION_THRESHOLD
+            and not utilization["total_rate_limit_errors"]
+        ):
+            query = text(
+                "SELECT COUNT(*) AS total_count, "
+                "COUNT(CASE WHEN miner_hotkey = :hotkey THEN 1 ELSE NULL END) AS hotkey_count "
+                "FROM instances WHERE chute_id = :chute_id"
             )
-        gpu_type = node.name
-        if not node.is_suitable(chute):
+            count_result = (
+                (await db.execute(query, {"chute_id": chute_id, "hotkey": hotkey}))
+                .mappings()
+                .first()
+            )
+            if count_result["total_count"] >= UNDERUTILIZED_CAP or count_result.hotkey_count:
+                raise HTTPException(
+                    status_code=status.HTTP_423_LOCKED,
+                    detail=f"Chute {chute_id} is underutilized and either at capacity or you already have an instance.",
+                )
+
+        # Load the miner.
+        miner = await get_miner_by_hotkey(hotkey, db)
+        if not miner:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail=f"Did not find miner with {hotkey=}",
+            )
+
+        # Validate the hostname.
+        if not await is_valid_host(instance_args.host):
             logger.warning(
-                f"INSTANCEFAIL: attempt to post incompatible GPUs: {node.name} for {chute.node_selector}"
+                f"INSTANCEFAIL: Attempt to post bad host: {instance_args.host} from {hotkey=}"
             )
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Node {node_id} is not compatible with chute node selector!",
+                detail=f"Invalid instance host: {instance_args.host}",
             )
-        await db.execute(
-            instance_nodes.insert().values(instance_id=instance.instance_id, node_id=node_id)
-        )
 
-    # Persist, which will raise a unique constraint error when the node is already allocated.
-    try:
+        # Instantiate the instance.
+        instance = Instance(
+            instance_id=generate_uuid(),
+            host=instance_args.host,
+            port=instance_args.port,
+            chute_id=chute_id,
+            miner_uid=miner.node_id,
+            miner_hotkey=hotkey,
+            miner_coldkey=miner.coldkey,
+            region="n/a",
+            active=False,
+            verified=False,
+            chutes_version=chute.chutes_version,
+        )
+        db.add(instance)
+
+        # Verify the GPUs are suitable.
+        gpu_count = chute.node_selector.get("gpu_count", 1)
+        if len(instance_args.node_ids) != gpu_count:
+            logger.warning(
+                f"INSTANCEFAIL: Attempt to post incorrect GPU count: {len(instance_args.node_ids)} vs {gpu_count} from {hotkey=}"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Chute {chute_id} requires exactly {gpu_count} GPUs.",
+            )
+        gpu_type = None
+        for node_id in instance_args.node_ids:
+            node = await get_node_by_id(node_id, db, hotkey)
+            if not node:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Node {node_id} not found",
+                )
+            gpu_type = node.name
+            if not node.is_suitable(chute):
+                logger.warning(
+                    f"INSTANCEFAIL: attempt to post incompatible GPUs: {node.name} for {chute.node_selector}"
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Node {node_id} is not compatible with chute node selector!",
+                )
+            await db.execute(
+                instance_nodes.insert().values(instance_id=instance.instance_id, node_id=node_id)
+            )
+
+        # Persist, which will raise a unique constraint error when the node is already allocated.
         await db.commit()
     except IntegrityError as exc:
         await db.rollback()
@@ -119,6 +147,8 @@ async def create_instance(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Unknown database integrity error",
         )
+    finally:
+        await db.execute(text("SELECT pg_advisory_unlock(:lock_id)"), {"lock_id": lock_id})
     await db.refresh(instance)
 
     # Broadcast the event.

--- a/api/instance/router.py
+++ b/api/instance/router.py
@@ -48,6 +48,9 @@ async def create_instance(
     if chute.rolling_update:
         limit = chute.rolling_update.permitted.get(hotkey, 0)
         if not limit:
+            logger.warning(
+                f"SCALELOCK: chute {chute_id=} {chute.name} is currently undergoing a rolling update"
+            )
             raise HTTPException(
                 status_code=status.HTTP_423_LOCKED,
                 detail=f"Chute {chute_id} is currently undergoing a rolling update and you have no quota, try again later.",
@@ -78,6 +81,9 @@ async def create_instance(
                 .first()
             )
             if count_result["total_count"] >= UNDERUTILIZED_CAP or count_result.hotkey_count:
+                logger.warning(
+                    f"SCALELOCK: chute {chute_id=} {chute.name} is currently capped: {count_result}"
+                )
                 raise HTTPException(
                     status_code=status.HTTP_423_LOCKED,
                     detail=f"Chute {chute_id} is underutilized and either at capacity or you already have an instance.",

--- a/api/instance/schemas.py
+++ b/api/instance/schemas.py
@@ -46,6 +46,7 @@ class Instance(Base):
     host = Column(String, nullable=False)
     port = Column(Integer, nullable=False)
     chute_id = Column(String, ForeignKey("chutes.chute_id", ondelete="CASCADE"), nullable=False)
+    version = Column(String, nullable=False)
     miner_uid = Column(Integer, nullable=False)
     miner_hotkey = Column(String, nullable=False)
     miner_coldkey = Column(String, nullable=False)

--- a/api/migrations/20250423083926_instance_version.sql
+++ b/api/migrations/20250423083926_instance_version.sql
@@ -1,0 +1,14 @@
+-- migrate:up
+ALTER TABLE instances ADD COLUMN version text NOT NULL DEFAULT '';
+
+UPDATE instances 
+SET version = (
+  SELECT chutes.version 
+  FROM chutes 
+  WHERE chutes.chute_id = instances.chute_id
+);
+
+ALTER TABLE instances ALTER COLUMN version DROP DEFAULT;
+
+-- migrate:down
+ALTER TABLE instances DROP COLUMN IF EXISTS version;

--- a/api/miner/router.py
+++ b/api/miner/router.py
@@ -136,10 +136,14 @@ async def get_chute(
 ):
     async with get_session() as db:
         chute = (
-            await db.execute(
-                select(Chute).where(Chute.chute_id == chute_id).where(Chute.version == version)
+            (
+                await db.execute(
+                    select(Chute).where(Chute.chute_id == chute_id).where(Chute.version == version)
+                )
             )
-        ).scalar_one_or_none()
+            .unique()
+            .scalar_one_or_none()
+        )
         if not chute:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,

--- a/api/util.py
+++ b/api/util.py
@@ -191,6 +191,7 @@ async def _limit_dev_activity(session, user, maximum, clazz):
         user.username in ("chutes", "rayonlabs")
         or user.validator_hotkey
         or user.subnet_owner_hotkey
+        or user.user_id == "b167f56b-3e8d-5ffa-88bf-5cc6513bb6f4"
     ):
         return
 


### PR DESCRIPTION
```sql
chutes=> select sum(instance_count * gpu_count) from (select t.chute_id, case when count > 7 then count - 7 else 0 end as instance_count, (chutes.node_selector->>'gpu_count')::int as gpu_count from (select chutes.chute_id, chutes.name, cu.avg_busy_ratio, count(*) from chutes join chute_utilization cu on chutes.chute_id = cu.chute_id join instances on instances.chute_id = chutes.chute_id where cu.avg_busy_ratio < 0.05 group by chutes.chute_id, chutes.name, cu.avg_busy_ratio) t join chutes on t.chute_id = chutes.chute_id);
 sum
------
 2335
(1 row)
chutes=> select 2335.0 * 0.5 * 24.0;
 ?column?
-----------
 28020.000
(1 row)
chutes=> select 28020.000*365;
   ?column?
--------------
 10227300.000
 ```
 
 For example, with the current inventory and assuming an average GPU price of $0.5/hr (which is a very low estimate), this could reduce up to $10m/year of "forced" sell pressure from miners just to pay infra bills.