### PR TITLE
Misc fixes/enhancements for jobs

### DIFF
--- a/api/instance/router.py
+++ b/api/instance/router.py
@@ -290,7 +290,7 @@ async def get_launch_config(
         # Track this miner in the job history.
         await db.execute(
             text(
-                "UPDATE jobs SET miner_history = miner_history || jsonb_build_array(:hotkey) "
+                "UPDATE jobs SET miner_history = miner_history || jsonb_build_array(CAST(:hotkey AS TEXT))"
                 "WHERE job_id = :job_id"
             ),
             {"job_id": job_id, "hotkey": hotkey},

--- a/api/instance/router.py
+++ b/api/instance/router.py
@@ -1,5 +1,5 @@
 """
-Routes for instances with updated job assignment logic.
+Routes for instances.
 """
 
 import os

--- a/api/instance/schemas.py
+++ b/api/instance/schemas.py
@@ -112,7 +112,9 @@ class LaunchConfig(Base):
     env_key = Column(String, nullable=False)
     chute_id = Column(String, ForeignKey("chutes.chute_id", ondelete="CASCADE"), nullable=False)
     job_id = Column(
-        String, ForeignKey("jobs.job_id", ondelete="CASCADE"), nullable=True, unique=True
+        String,
+        ForeignKey("jobs.job_id", ondelete="CASCADE"),
+        nullable=True,
     )
     host = Column(String, nullable=True)
     port = Column(Integer, nullable=True)

--- a/api/invocation/router.py
+++ b/api/invocation/router.py
@@ -8,7 +8,6 @@ import gzip
 import orjson as json
 import csv
 import uuid
-import random
 import decimal
 from loguru import logger
 from pydantic import BaseModel, ValidationError, Field
@@ -823,7 +822,7 @@ async def hostname_invocation(
                     "grammar",
                 ]
             )
-            if problematic or random.random() <= 0.25:
+            if problematic:
                 payload["model"] = "moonshotai/Kimi-K2-Instruct-tools"
 
         model = payload.get("model")

--- a/api/job/response.py
+++ b/api/job/response.py
@@ -26,9 +26,10 @@ class JobResponse(BaseModel):
     finished_at: Optional[datetime] = None
 
     job_args: dict
-    final_result: Optional[dict] = None
+    result: Optional[dict] = None
     output_files: Optional[dict[str, Any]] = []
 
+    host: Optional[str] = None
     port_mappings: Optional[list[dict[str, Any]]] = []
 
     chute: MinimalChuteResponse

--- a/api/migrations/20250720084231_job_uq_fix.sql
+++ b/api/migrations/20250720084231_job_uq_fix.sql
@@ -1,0 +1,6 @@
+-- migrate:up
+ALTER TABLE launch_configs DROP CONSTRAINT IF EXISTS uq_job_launch_config;
+DROP INDEX IF EXISTS launch_configs_job_id_key;
+
+-- migrate:down
+ALTER TABLE launch_configs ADD CONSTRAINT uq_job_launch_config UNIQUE (job_id);


### PR DESCRIPTION
- don't assign miner until there's actually a pod starting up
- don't limit scaling chutes with high demand in rolling update scenarios
- atomic miner assignment on jobs
- allow several miners to try launching a job via launch config, but only one actual assignment
- change job file download to use the file ID