### PR TITLE
Update feature weights, use the moving average seconds per step/token per invocation to calculate compute units.

### DIFF
--- a/api/invocation/router.py
+++ b/api/invocation/router.py
@@ -9,6 +9,7 @@ import orjson as json
 import csv
 import uuid
 import decimal
+import random
 from loguru import logger
 from pydantic import BaseModel, ValidationError, Field
 from datetime import date, datetime
@@ -822,7 +823,7 @@ async def hostname_invocation(
                     "grammar",
                 ]
             )
-            if problematic:
+            if problematic or random.random() <= 0.15:
                 payload["model"] = "moonshotai/Kimi-K2-Instruct-tools"
 
         model = payload.get("model")

--- a/metasync/constants.py
+++ b/metasync/constants.py
@@ -37,7 +37,7 @@ SELECT
     ) AS compute_units
 FROM invocations i
 JOIN metagraph_nodes mn ON i.miner_hotkey = mn.hotkey AND mn.netuid = 64
-WHERE i.started_at > NOW() - INTERVAL '7 days'
+WHERE i.started_at > NOW() - INTERVAL '{interval}'
 AND i.error_message IS NULL
 AND i.miner_uid >= 0
 AND i.completed_at IS NOT NULL


### PR DESCRIPTION
- increase unique chute gpu weight (reduce invocation count weight)
- increase bounty count weight (reduce compute unit weight)
- use the dynamically calculated moving average seconds per step/token so compute units are atomic (don't fluctuate with median performance per 2 days) 