### PR TITLE
Private-only user/custom chutes, price updates, etc.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -153,8 +153,8 @@ ADD --chown=chutes metasync /app/metasync
 ADD --chown=chutes tokenizer /app/tokenizer
 ADD --chown=chutes watchtower.py /app/watchtower.py
 ADD --chown=chutes cacher.py /app/cacher.py
-ADD --chown=chutes downscaler.py /app/downscaler.py
 ADD --chown=chutes chute_autoscaler.py /app/chute_autoscaler.py
+ADD --chown=chutes balance_refresher.py /app/balance_refresher.py
 ADD --chown=chutes data/cache_hit_cluster_params.json /app/cache_hit_cluster_params.json
 ENV PYTHONPATH=/app
 ENTRYPOINT ["poetry", "run", "uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/api/chute/response.py
+++ b/api/chute/response.py
@@ -54,6 +54,8 @@ class ChuteResponse(BaseModel):
     concurrency: Optional[int] = None
     boost: Optional[float] = None
     logging_enabled: Optional[bool] = False
+    max_instances: Optional[int] = None
+    shutdown_after_seconds: Optional[int] = None
 
     class Config:
         from_attributes = True

--- a/api/chute/response.py
+++ b/api/chute/response.py
@@ -55,6 +55,7 @@ class ChuteResponse(BaseModel):
     boost: Optional[float] = None
     logging_enabled: Optional[bool] = False
     max_instances: Optional[int] = None
+    scaling_threshold: Optional[float] = None
     shutdown_after_seconds: Optional[int] = None
 
     class Config:

--- a/api/chute/router.py
+++ b/api/chute/router.py
@@ -982,6 +982,11 @@ async def _deploy_chute(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="A chute must define at least one cord() or job() function!",
         )
+    elif chute.cords and chute.jobs:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="A chute can have jobs or cords not both.",
+        )
 
     await db.commit()
     await db.refresh(chute)

--- a/api/chute/router.py
+++ b/api/chute/router.py
@@ -703,7 +703,7 @@ async def _deploy_chute(
     """
     Deploy a chute!
     """
-    if chute_args.public and current_user.user_id != await chutes_user_id():
+    if chute_args.public and not current_user.has_role(Permissioning.public_model_deployment):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=(
@@ -892,7 +892,9 @@ async def _deploy_chute(
         chute.ref_str = chute_args.ref_str
         chute.version = version
         chute.public = (
-            chute_args.public if current_user.user_id == await chutes_user_id() else False,
+            chute_args.public
+            if current_user.has_role(Permissioning.public_model_deployment)
+            else False,
         )
         chute.logo_id = (
             chute_args.logo_id if chute_args.logo_id and chute_args.logo_id.strip() else None
@@ -924,7 +926,7 @@ async def _deploy_chute(
                 ref_str=chute_args.ref_str,
                 version=version,
                 public=chute_args.public
-                if current_user.user_id == await chutes_user_id()
+                if current_user.has_permission(Permissioning.public_model_deployment)
                 else False,
                 cords=chute_args.cords,
                 jobs=chute_args.jobs,

--- a/api/chute/router.py
+++ b/api/chute/router.py
@@ -16,11 +16,13 @@ from sqlalchemy import or_, exists, func, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from sqlalchemy.orm import selectinload
+from sqlalchemy.dialects.postgresql import insert
 from typing import Optional
 from api.constants import EXPANSION_UTILIZATION_THRESHOLD, UNDERUTILIZED_CAP
 from api.chute.schemas import (
     Chute,
     ChuteArgs,
+    ChuteShare,
     NodeSelector,
     ChuteUpdateArgs,
     RollingUpdate,
@@ -696,10 +698,19 @@ async def _deploy_chute(
     db: AsyncSession,
     current_user: User,
     use_rolling_update: bool = True,
+    confirm_fee: bool = False,
 ):
     """
     Deploy a chute!
     """
+    if chute_args.public and current_user.user_id != await chutes_user_id():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "Chutes no longer supports public chutes. You can instead "
+                "deploy the chute as a private chute and share it with other users."
+            ),
+        )
     image = await get_image_by_id_or_name(chute_args.image, db, current_user)
     if not image:
         raise HTTPException(
@@ -740,6 +751,43 @@ async def _deploy_chute(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You are not allowed to require 5090s",
         )
+
+    # Fee estimate, as an error, if the user hasn't used the confirmed param.
+    estimate = chute_args.node_selector.current_estimated_price
+    deployment_fee = chute_args.node_selector.gpu_count * estimate["usd"]["hour"] * 3
+    if not confirm_fee:
+        estimate = chute_args.node_selector.current_estimated_price
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail=(
+                "There is a deployment fee of (hourly price per GPU * number of GPUs * 3), "
+                f"which for this configuration is for this configuration is: ${deployment_fee}\n "
+                "To acknowledge this fee, upgrade your chutes version to latest and "
+                "re-run the deploy command with --accept-fee\n"
+                "(or if deploying via API manually, add confirm_fee=true param)"
+            ),
+        )
+    if current_user.balance <= deployment_fee:
+        logger.warning(
+            f"Payment required: attempted deployment of chute {chute_args.name} "
+            f"from user {current_user.username} with balance < {deployment_fee=}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_402_PAYMENT_REQUIRED,
+            detail=(
+                f"The deployment fee, based on your node selector, is ${deployment_fee}, "
+                f"but you have a balance of {current_user.balance}.\n"
+                f"Please top up your account with tao @ {current_user.payment_address} or via fiat."
+            ),
+        )
+
+    # Deduct the deployment fee.
+    current_user.balance -= deployment_fee
+    logger.info(
+        f"DEPLOYMENTFEE: {deployment_fee} for {current_user.username=} with "
+        f"{chute_args.node_selector=} of {chute_args.name=}, new balance={current_user.balance}"
+    )
+
     affine_dev = await is_affine_registered(db, current_user)
     if (
         current_user.user_id != await chutes_user_id()
@@ -843,7 +891,9 @@ async def _deploy_chute(
         chute.filename = chute_args.filename
         chute.ref_str = chute_args.ref_str
         chute.version = version
-        chute.public = chute_args.public
+        chute.public = (
+            chute_args.public if current_user.user_id == await chutes_user_id() else False,
+        )
         chute.logo_id = (
             chute_args.logo_id if chute_args.logo_id and chute_args.logo_id.strip() else None
         )
@@ -873,7 +923,9 @@ async def _deploy_chute(
                 filename=chute_args.filename,
                 ref_str=chute_args.ref_str,
                 version=version,
-                public=chute_args.public,
+                public=chute_args.public
+                if current_user.user_id == await chutes_user_id()
+                else False,
                 cords=chute_args.cords,
                 jobs=chute_args.jobs,
                 node_selector=chute_args.node_selector,
@@ -882,7 +934,6 @@ async def _deploy_chute(
                 concurrency=chute_args.concurrency,
                 revision=chute_args.revision,
                 logging_enabled=chute_args.logging_enabled,
-                discount=-10.0 if "affine" in chute_args.name.lower() else None,
             )
         except ValueError as exc:
             raise HTTPException(
@@ -971,6 +1022,7 @@ async def _deploy_chute(
 @router.post("/", response_model=ChuteResponse)
 async def deploy_chute(
     chute_args: ChuteArgs,
+    confirm_fee: Optional[bool] = False,
     db: AsyncSession = Depends(get_db_session),
     current_user: User = Depends(get_current_user()),
 ):
@@ -1087,22 +1139,20 @@ async def deploy_chute(
                 detail=json.dumps(response).decode(),
             )
     chute = await _deploy_chute(
-        chute_args, db, current_user, use_rolling_update=not is_affine_model
+        chute_args,
+        db,
+        current_user,
+        use_rolling_update=not is_affine_model,
+        confirm_fee=confirm_fee,
     )
 
     # Auto-cleanup the other chutes for affine miners.
-    if (
-        is_affine_model
-        and not current_user.has_role(Permissioning.unlimited_dev)
-        and current_user.username.lower() not in ("affine", "affine2", "nonaffine", "unconst")
-    ):
-        old_chutes = (
+    if is_affine_model:
+        af_dev_user_ids = (
             (
                 await db.execute(
-                    select(Chute).where(
-                        Chute.user_id == current_user.user_id,
-                        Chute.name.ilike("%affine%"),
-                        Chute.chute_id != chute.chute_id,  # noqa
+                    select(User.user_id).where(
+                        User.permissions_bitmask.op("&")(Permissioning.affine_dev.bitmask) != 0
                     )
                 )
             )
@@ -1110,20 +1160,22 @@ async def deploy_chute(
             .scalars()
             .all()
         )
-        for old_chute in old_chutes:
-            await db.delete(old_chute)
-            await settings.redis_client.publish(
-                "miner_broadcast",
-                json.dumps(
+        if af_dev_user_ids:
+            stmt = insert(ChuteShare).values(
+                [
                     {
-                        "reason": "chute_deleted",
-                        "data": {"chute_id": old_chute.chute_id, "version": old_chute.version},
+                        "chute_id": chute.chute_id,
+                        "shared_by": current_user.user_id,
+                        "shared_to": user_id,
+                        "shared_at": func.now(),
                     }
-                ).decode(),
+                    for user_id in af_dev_user_ids
+                    if user_id != current_user.user_id
+                ]
             )
-            logger.success(
-                f"Auto-cleaned {old_chute.chute_id=} {old_chute.name=} from {old_chute.user_id=} for affine"
-            )
+            stmt = stmt.on_conflict_do_nothing()
+            await db.execute(stmt)
+
     return chute
 
 

--- a/api/chute/schemas.py
+++ b/api/chute/schemas.py
@@ -20,6 +20,8 @@ class ChuteUpdateArgs(BaseModel):
     readme: Optional[str] = Field(default="", max_length=16384)
     tool_description: Optional[str] = Field(default="", max_length=16384)
     logo_id: Optional[str] = None
+    max_instances: Optional[int] = Field(default=1, ge=1, le=100)
+    shutdown_after_seconds: Optional[int] = Field(default=300, ge=60, le=604800)
 
 
 class Cord(BaseModel):
@@ -170,6 +172,8 @@ class ChuteArgs(BaseModel):
     concurrency: Optional[int] = Field(None, gte=0, le=256)
     revision: Optional[str] = Field(None, pattern=r"^[a-fA-F0-9]{40}$")
     logging_enabled: Optional[bool] = False
+    max_instances: Optional[int] = Field(default=1, ge=1, le=100)
+    shutdown_after_seconds: Optional[int] = Field(default=300, ge=60, le=604800)
 
 
 class InvocationArgs(BaseModel):
@@ -206,6 +210,8 @@ class Chute(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), server_default=func.now())
     logging_enabled = Column(Boolean, default=False)
+    max_instances = Column(Integer, nullable=True)
+    shutdown_after_seconds = Column(Integer, nullable=True)
 
     # Stats for sorting.
     invocation_count = Column(BigInteger, default=0)

--- a/api/chute/schemas.py
+++ b/api/chute/schemas.py
@@ -6,7 +6,16 @@ import re
 import ast
 from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship, validates
-from sqlalchemy import Column, Float, String, DateTime, Boolean, ForeignKey, BigInteger, Integer
+from sqlalchemy import (
+    Column,
+    String,
+    DateTime,
+    Boolean,
+    ForeignKey,
+    BigInteger,
+    Integer,
+    Float,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from api.database import Base
 from api.gpu import SUPPORTED_GPUS, COMPUTE_MULTIPLIER, COMPUTE_UNIT_PRICE_BASIS
@@ -21,6 +30,7 @@ class ChuteUpdateArgs(BaseModel):
     tool_description: Optional[str] = Field(default="", max_length=16384)
     logo_id: Optional[str] = None
     max_instances: Optional[int] = Field(default=1, ge=1, le=100)
+    scaling_threshold: Optional[float] = Field(default=0.75, ge=0.0, le=1.0)
     shutdown_after_seconds: Optional[int] = Field(default=300, ge=60, le=604800)
 
 
@@ -173,6 +183,7 @@ class ChuteArgs(BaseModel):
     revision: Optional[str] = Field(None, pattern=r"^[a-fA-F0-9]{40}$")
     logging_enabled: Optional[bool] = False
     max_instances: Optional[int] = Field(default=1, ge=1, le=100)
+    scaling_threshold: Optional[float] = Field(default=0.75, ge=0.0, le=1.0)
     shutdown_after_seconds: Optional[int] = Field(default=300, ge=60, le=604800)
 
 
@@ -211,6 +222,7 @@ class Chute(Base):
     updated_at = Column(DateTime(timezone=True), server_default=func.now())
     logging_enabled = Column(Boolean, default=False)
     max_instances = Column(Integer, nullable=True)
+    scaling_threshold = Column(Float, nullable=True)
     shutdown_after_seconds = Column(Integer, nullable=True)
 
     # Stats for sorting.

--- a/api/chute/util.py
+++ b/api/chute/util.py
@@ -860,7 +860,7 @@ async def invoke(
                     compute_units = result.scalar_one_or_none()
                     balance_used = 0.0
                     override_applied = False
-                    if compute_units and not request.state.free_invocation:
+                    if chute.public and compute_units and not request.state.free_invocation:
                         hourly_price = await selector_hourly_price(chute.node_selector)
 
                         if (
@@ -988,7 +988,7 @@ async def invoke(
                         logger.error(f"Error updating usage pipeline: {exc}")
 
                     # Increment quota usage value.
-                    if chute.discount < 1.0:
+                    if chute.public and chute.discount < 1.0:
                         try:
                             value = 1.0 if not reroll else settings.reroll_multiplier
                             key = await InvocationQuota.quota_key(user.user_id, chute.chute_id)

--- a/api/chute/util.py
+++ b/api/chute/util.py
@@ -50,7 +50,7 @@ from api.user.schemas import User, InvocationQuota, InvocationDiscount, PriceOve
 from api.user.service import chutes_user_id
 from api.miner_client import sign_request
 from api.instance.schemas import Instance
-from api.instance.util import LeastConnManager
+from api.instance.util import LeastConnManager, update_shutdown_timestamp
 from api.gpu import COMPUTE_UNIT_PRICE_BASIS
 from api.metrics.vllm import track_usage as track_vllm_usage
 from api.metrics.perf import PERF_TRACKER
@@ -997,6 +997,10 @@ async def invoke(
                             logger.error(
                                 f"Error updating quota usage for {user.user_id} chute {chute.chute_id}: {exc}"
                             )
+
+                    # For private chutes, push back the instance termination timestamp.
+                    if not chute.public:
+                        await update_shutdown_timestamp(target.instance_id)
 
                     await session.commit()
 

--- a/api/constants.py
+++ b/api/constants.py
@@ -15,20 +15,23 @@ ENCRYPTED_HEADER = "X-Chutes-Encrypted"
 # per million really can change depending on the node selector.
 # For example:
 #  llama-3-8b with node selector requiring minimally an h100
-#  Example h100 hourly price (subject to change): $1.15
-#  $/million = $1.15 * 0.016447 = $0.01891405/million input
-#            = $1.15 * 0.065785 = $0.07565275/million output
+#  Example h100 hourly price (subject to change): $1.5
+#  $/million = $1.5 * 0.01358695 = $0.02/million input
+#            = $1.5 * 0.05434782 = $0.08/million output
 # Deepseek example, 8x h200:
-#  $1.9 * 8 * 0.016447 = $0.25/million input
-#  $1.9 * 8 * 0.065785 = $1.00/million output
+#  $2.3 * 8 * 0.01358695 = $0.25/million input
+#  $2.3 * 8 * 0.05434782 = $1.00/million output
 # NOTE: there is also a multiplier when the chute's concurrency is < 16,
 # because for example the concurrency may be reduced to accomodate more
 # total concurrent tokens in KV cache, such as GLM-4.5-FP8 at full context
 # has concurrency 12, so:
-#  $1.9 * 8 * 16/12 * 0.016447 = $0.33/million input
-#  $1.9 * 8 * 16/12 * 0.065785 = $1.33/million output
-LLM_PRICE_MULT_PER_MILLION_IN = 0.016447
-LLM_PRICE_MULT_PER_MILLION_OUT = 0.065785
+#  $2.3 * 8 * 16/12 * 0.01358695 = $0.33/million input
+#  $2.3 * 8 * 16/12 * 0.05434782 = $1.33/million output
+# Kimi-K2 example (8xb200)
+#  $3.5 * 8 * 0.01358695 = $0.38
+#  $3.5 * 8 * 0.05434782 = $1.52
+LLM_PRICE_MULT_PER_MILLION_IN = 0.01358695
+LLM_PRICE_MULT_PER_MILLION_OUT = 0.05434782
 LLM_MIN_PRICE_IN = 0.01
 LLM_MIN_PRICE_OUT = 0.01
 

--- a/api/constants.py
+++ b/api/constants.py
@@ -14,12 +14,15 @@ ENCRYPTED_HEADER = "X-Chutes-Encrypted"
 # any particular model, e.g. you could run a llama 8b on 1 node or 8, so the price
 # per million really can change depending on the node selector.
 # For example:
-#  llama-3-8b with node selector requiring minimally an a100
-#  Example a100 hourly price (subject to change): $0.8
-#  $/million = $0.8 * 0.010643825 = $0.0085150600/million input
-#            = $0.8 * 0.0463000   = $0.03704000/million output
-LLM_PRICE_MULT_PER_MILLION_IN = 0.010643825
-LLM_PRICE_MULT_PER_MILLION_OUT = 0.0463000
+#  llama-3-8b with node selector requiring minimally an h100
+#  Example h100 hourly price (subject to change): $1.15
+#  $/million = $1.15 * 0.016447 = $0.01891405/million input
+#            = $1.15 * 0.065785 = $0.07565275/million output
+# Deepseek example, 8x h200:
+#  $1.9 * 8 * 0.016447 = $0.25/million input
+#  $1.9 * 8 * 0.065785 = $1.00/million output
+LLM_PRICE_MULT_PER_MILLION_IN = 0.016447
+LLM_PRICE_MULT_PER_MILLION_OUT = 0.065785
 LLM_MIN_PRICE_IN = 0.01
 LLM_MIN_PRICE_OUT = 0.01
 

--- a/api/constants.py
+++ b/api/constants.py
@@ -21,6 +21,12 @@ ENCRYPTED_HEADER = "X-Chutes-Encrypted"
 # Deepseek example, 8x h200:
 #  $1.9 * 8 * 0.016447 = $0.25/million input
 #  $1.9 * 8 * 0.065785 = $1.00/million output
+# NOTE: there is also a multiplier when the chute's concurrency is < 16,
+# because for example the concurrency may be reduced to accomodate more
+# total concurrent tokens in KV cache, such as GLM-4.5-FP8 at full context
+# has concurrency 12, so:
+#  $1.9 * 8 * 16/12 * 0.016447 = $0.33/million input
+#  $1.9 * 8 * 16/12 * 0.065785 = $1.33/million output
 LLM_PRICE_MULT_PER_MILLION_IN = 0.016447
 LLM_PRICE_MULT_PER_MILLION_OUT = 0.065785
 LLM_MIN_PRICE_IN = 0.01

--- a/api/constants.py
+++ b/api/constants.py
@@ -16,10 +16,10 @@ ENCRYPTED_HEADER = "X-Chutes-Encrypted"
 # For example:
 #  llama-3-8b with node selector requiring minimally an a100
 #  Example a100 hourly price (subject to change): $0.8
-#  $/million = $0.8 * 0.0092555 = $0.007404/million input
-#            = $0.8 * 0.03704   = $0.029632/million output
-LLM_PRICE_MULT_PER_MILLION_IN = 0.0092555
-LLM_PRICE_MULT_PER_MILLION_OUT = 0.03704
+#  $/million = $0.8 * 0.010643825 = $0.0085150600/million input
+#            = $0.8 * 0.0463000   = $0.03704000/million output
+LLM_PRICE_MULT_PER_MILLION_IN = 0.010643825
+LLM_PRICE_MULT_PER_MILLION_OUT = 0.0463000
 LLM_MIN_PRICE_IN = 0.01
 LLM_MIN_PRICE_OUT = 0.01
 

--- a/api/gpu.py
+++ b/api/gpu.py
@@ -15,7 +15,7 @@ SUPPORTED_GPUS = {
         "processors": 82,
         "clock_rate": {"base": 1395, "boost": 1695},
         "max_threads_per_processor": 1536,
-        "hourly_rate": 0.3,
+        "hourly_rate": 0.09,
         "graval": {
             "estimate": 70,
             "iterations": 1,
@@ -33,7 +33,7 @@ SUPPORTED_GPUS = {
         "processors": 128,
         "clock_rate": {"base": 2235, "boost": 2520},
         "max_threads_per_processor": 1536,
-        "hourly_rate": 0.50,
+        "hourly_rate": 0.2,
         "graval": {
             "iterations": 2,
             "estimate": 65,
@@ -51,7 +51,7 @@ SUPPORTED_GPUS = {
         "sxm": False,
         "processors": 170,
         "clock_rate": {"base": 2017, "boost": 2407},
-        "hourly_rate": 0.7,
+        "hourly_rate": 0.25,
         "graval": {
             "iterations": 2,
             "estimate": 60,
@@ -69,7 +69,7 @@ SUPPORTED_GPUS = {
         "processors": 48,
         "clock_rate": {"base": 765, "boost": 1560},
         "max_threads_per_processor": 1536,
-        "hourly_rate": 0.2,
+        "hourly_rate": 0.07,
         "graval": {
             "iterations": 1,
             "estimate": 75,
@@ -87,7 +87,7 @@ SUPPORTED_GPUS = {
         "processors": 48,
         "clock_rate": {"base": 765, "boost": 2175},
         "max_threads_per_processor": 1536,
-        "hourly_rate": 0.22,
+        "hourly_rate": 0.1,
         "graval": {
             "iterations": 1,
             "estimate": 80,
@@ -105,7 +105,7 @@ SUPPORTED_GPUS = {
         "processors": 64,
         "clock_rate": {"base": 1170, "boost": 1695},
         "max_threads_per_processor": 1536,
-        "hourly_rate": 0.23,
+        "hourly_rate": 0.13,
         "graval": {
             "iterations": 1,
             "estimate": 92,
@@ -123,7 +123,7 @@ SUPPORTED_GPUS = {
         "processors": 84,
         "clock_rate": {"base": 1455, "boost": 1860},
         "max_threads_per_processor": 1536,
-        "hourly_rate": 0.4,
+        "hourly_rate": 0.27,
         "graval": {
             "iterations": 1,
             "estimate": 140,
@@ -141,7 +141,7 @@ SUPPORTED_GPUS = {
         "processors": 142,
         "clock_rate": {"base": 915, "boost": 2505},
         "max_threads_per_processor": 1536,
-        "hourly_rate": 0.65,
+        "hourly_rate": 0.27,
         "graval": {
             "iterations": 1,
             "estimate": 60,
@@ -159,7 +159,7 @@ SUPPORTED_GPUS = {
         "processors": 58,
         "clock_rate": {"base": 795, "boost": 2040},
         "max_threads_per_processor": 1536,
-        "hourly_rate": 0.32,
+        "hourly_rate": 0.15,
         "graval": {
             "iterations": 1,
             "estimate": 85,
@@ -177,7 +177,7 @@ SUPPORTED_GPUS = {
         "processors": 72,
         "clock_rate": {"base": 1110, "boost": 1710},
         "max_threads_per_processor": 1536,
-        "hourly_rate": 0.5,
+        "hourly_rate": 0.25,
         "graval": {
             "iterations": 1,
             "estimate": 82,
@@ -213,7 +213,7 @@ SUPPORTED_GPUS = {
         "processors": 142,
         "clock_rate": {"base": 735, "boost": 2490},
         "max_threads_per_processor": 1536,
-        "hourly_rate": 0.6,
+        "hourly_rate": 0.3,
         "graval": {
             "iterations": 1,
             "estimate": 60,
@@ -231,7 +231,7 @@ SUPPORTED_GPUS = {
         "processors": 142,
         "clock_rate": {"base": 1065, "boost": 2520},
         "max_threads_per_processor": 1536,
-        "hourly_rate": 0.65,
+        "hourly_rate": 0.3,
         "graval": {
             "iterations": 1,
             "estimate": 60,
@@ -249,7 +249,7 @@ SUPPORTED_GPUS = {
         "processors": 108,
         "clock_rate": {"base": 1065, "boost": 1410},
         "max_threads_per_processor": 2048,
-        "hourly_rate": 0.8,
+        "hourly_rate": 0.45,
         "graval": {
             "iterations": 4,
             "estimate": 60,
@@ -267,7 +267,7 @@ SUPPORTED_GPUS = {
         "processors": 108,
         "clock_rate": {"base": 1065, "boost": 1410},
         "max_threads_per_processor": 2048,
-        "hourly_rate": 0.85,
+        "hourly_rate": 0.5,
         "graval": {
             "iterations": 4,
             "estimate": 60,
@@ -285,7 +285,7 @@ SUPPORTED_GPUS = {
         "processors": 108,
         "clock_rate": {"base": 1065, "boost": 1410},
         "max_threads_per_processor": 2048,
-        "hourly_rate": 0.9,
+        "hourly_rate": 0.45,
         "graval": {
             "iterations": 2,
             "estimate": 58,
@@ -303,7 +303,7 @@ SUPPORTED_GPUS = {
         "processors": 108,
         "clock_rate": {"base": 1275, "boost": 1410},
         "max_threads_per_processor": 2048,
-        "hourly_rate": 0.95,
+        "hourly_rate": 0.5,
         "graval": {
             "iterations": 3,
             "estimate": 70,
@@ -321,7 +321,7 @@ SUPPORTED_GPUS = {
         "processors": 114,
         "clock_rate": {"base": 1095, "boost": 1755},
         "max_threads_per_processor": 2048,
-        "hourly_rate": 1.4,
+        "hourly_rate": 1.15,
         "graval": {
             "iterations": 2,
             "estimate": 62,
@@ -339,7 +339,7 @@ SUPPORTED_GPUS = {
         "processors": 132,
         "clock_rate": {"base": 1590, "boost": 1980},
         "max_threads_per_processor": 2048,
-        "hourly_rate": 1.5,
+        "hourly_rate": 1.34,
         "graval": {
             "iterations": 3,
             "estimate": 75,
@@ -357,7 +357,7 @@ SUPPORTED_GPUS = {
         "processors": 132,
         "clock_rate": {"base": 1590, "boost": 1980},
         "max_threads_per_processor": 2048,
-        "hourly_rate": 1.6,
+        "hourly_rate": 1.25,
         "graval": {
             "iterations": 5,
             "estimate": 70,
@@ -375,7 +375,7 @@ SUPPORTED_GPUS = {
         "processors": 114,
         "clock_rate": {"base": 1095, "boost": 1755},
         "max_threads_per_processor": 2048,
-        "hourly_rate": 1.8,
+        "hourly_rate": 1.25,
         "graval": {
             "iterations": 3,
             "estimate": 75,
@@ -387,7 +387,7 @@ SUPPORTED_GPUS = {
         "processors": 78,
         "clock_rate": {"base": 1590, "boost": 1980},
         "max_threads_per_processor": 1024,
-        "hourly_rate": 0.7,
+        "hourly_rate": 0.5,
         "graval": {
             "iterations": 1,
             "estimate": 300,
@@ -405,7 +405,7 @@ SUPPORTED_GPUS = {
         "processors": 132,
         "clock_rate": {"base": 1590, "boost": 1980},
         "max_threads_per_processor": 2048,
-        "hourly_rate": 2.7,
+        "hourly_rate": 1.9,
         "graval": {
             "iterations": 3,
             "estimate": 70,
@@ -418,7 +418,7 @@ SUPPORTED_GPUS = {
         "processors": 304,
         "clock_rate": {"base": 1600, "boost": 2100},
         "max_threads_per_processor": 256,
-        "hourly_rate": 2.5,
+        "hourly_rate": 1.9,
         "graval": {
             "iterations": 2,
             "estimate": 75,
@@ -430,7 +430,7 @@ SUPPORTED_GPUS = {
         "processors": 148,
         "clock_rate": {"base": 1590, "boost": 1965},
         "max_threads_per_processor": 1024,
-        "hourly_rate": 4.0,
+        "hourly_rate": 3.15,
         "graval": {
             "iterations": 2,
             "estimate": 75,

--- a/api/gpu.py
+++ b/api/gpu.py
@@ -15,7 +15,7 @@ SUPPORTED_GPUS = {
         "processors": 82,
         "clock_rate": {"base": 1395, "boost": 1695},
         "max_threads_per_processor": 1536,
-        "hourly_rate": 0.09,
+        "hourly_rate": 0.12,
         "graval": {
             "estimate": 70,
             "iterations": 1,
@@ -33,7 +33,7 @@ SUPPORTED_GPUS = {
         "processors": 128,
         "clock_rate": {"base": 2235, "boost": 2520},
         "max_threads_per_processor": 1536,
-        "hourly_rate": 0.2,
+        "hourly_rate": 0.25,
         "graval": {
             "iterations": 2,
             "estimate": 65,
@@ -51,7 +51,7 @@ SUPPORTED_GPUS = {
         "sxm": False,
         "processors": 170,
         "clock_rate": {"base": 2017, "boost": 2407},
-        "hourly_rate": 0.25,
+        "hourly_rate": 0.35,
         "graval": {
             "iterations": 2,
             "estimate": 60,
@@ -69,7 +69,7 @@ SUPPORTED_GPUS = {
         "processors": 48,
         "clock_rate": {"base": 765, "boost": 1560},
         "max_threads_per_processor": 1536,
-        "hourly_rate": 0.07,
+        "hourly_rate": 0.1,
         "graval": {
             "iterations": 1,
             "estimate": 75,
@@ -87,7 +87,7 @@ SUPPORTED_GPUS = {
         "processors": 48,
         "clock_rate": {"base": 765, "boost": 2175},
         "max_threads_per_processor": 1536,
-        "hourly_rate": 0.1,
+        "hourly_rate": 0.11,
         "graval": {
             "iterations": 1,
             "estimate": 80,
@@ -105,7 +105,7 @@ SUPPORTED_GPUS = {
         "processors": 64,
         "clock_rate": {"base": 1170, "boost": 1695},
         "max_threads_per_processor": 1536,
-        "hourly_rate": 0.13,
+        "hourly_rate": 0.18,
         "graval": {
             "iterations": 1,
             "estimate": 92,
@@ -123,7 +123,7 @@ SUPPORTED_GPUS = {
         "processors": 84,
         "clock_rate": {"base": 1455, "boost": 1860},
         "max_threads_per_processor": 1536,
-        "hourly_rate": 0.27,
+        "hourly_rate": 0.33,
         "graval": {
             "iterations": 1,
             "estimate": 140,
@@ -141,7 +141,7 @@ SUPPORTED_GPUS = {
         "processors": 142,
         "clock_rate": {"base": 915, "boost": 2505},
         "max_threads_per_processor": 1536,
-        "hourly_rate": 0.27,
+        "hourly_rate": 0.36,
         "graval": {
             "iterations": 1,
             "estimate": 60,
@@ -159,7 +159,7 @@ SUPPORTED_GPUS = {
         "processors": 58,
         "clock_rate": {"base": 795, "boost": 2040},
         "max_threads_per_processor": 1536,
-        "hourly_rate": 0.15,
+        "hourly_rate": 0.17,
         "graval": {
             "iterations": 1,
             "estimate": 85,
@@ -195,7 +195,7 @@ SUPPORTED_GPUS = {
         "processors": 84,
         "clock_rate": {"base": 1305, "boost": 1740},
         "max_threads_per_processor": 1536,
-        "hourly_rate": 0.27,
+        "hourly_rate": 0.35,
         "graval": {
             "iterations": 1,
             "estimate": 142,
@@ -213,7 +213,7 @@ SUPPORTED_GPUS = {
         "processors": 142,
         "clock_rate": {"base": 735, "boost": 2490},
         "max_threads_per_processor": 1536,
-        "hourly_rate": 0.3,
+        "hourly_rate": 0.35,
         "graval": {
             "iterations": 1,
             "estimate": 60,
@@ -231,7 +231,7 @@ SUPPORTED_GPUS = {
         "processors": 142,
         "clock_rate": {"base": 1065, "boost": 2520},
         "max_threads_per_processor": 1536,
-        "hourly_rate": 0.3,
+        "hourly_rate": 0.41,
         "graval": {
             "iterations": 1,
             "estimate": 60,
@@ -249,7 +249,7 @@ SUPPORTED_GPUS = {
         "processors": 108,
         "clock_rate": {"base": 1065, "boost": 1410},
         "max_threads_per_processor": 2048,
-        "hourly_rate": 0.45,
+        "hourly_rate": 0.55,
         "graval": {
             "iterations": 4,
             "estimate": 60,
@@ -267,7 +267,7 @@ SUPPORTED_GPUS = {
         "processors": 108,
         "clock_rate": {"base": 1065, "boost": 1410},
         "max_threads_per_processor": 2048,
-        "hourly_rate": 0.5,
+        "hourly_rate": 0.57,
         "graval": {
             "iterations": 4,
             "estimate": 60,
@@ -285,7 +285,7 @@ SUPPORTED_GPUS = {
         "processors": 108,
         "clock_rate": {"base": 1065, "boost": 1410},
         "max_threads_per_processor": 2048,
-        "hourly_rate": 0.45,
+        "hourly_rate": 0.60,
         "graval": {
             "iterations": 2,
             "estimate": 58,
@@ -303,7 +303,7 @@ SUPPORTED_GPUS = {
         "processors": 108,
         "clock_rate": {"base": 1275, "boost": 1410},
         "max_threads_per_processor": 2048,
-        "hourly_rate": 0.5,
+        "hourly_rate": 0.62,
         "graval": {
             "iterations": 3,
             "estimate": 70,
@@ -321,7 +321,7 @@ SUPPORTED_GPUS = {
         "processors": 114,
         "clock_rate": {"base": 1095, "boost": 1755},
         "max_threads_per_processor": 2048,
-        "hourly_rate": 1.15,
+        "hourly_rate": 1.5,
         "graval": {
             "iterations": 2,
             "estimate": 62,
@@ -339,7 +339,7 @@ SUPPORTED_GPUS = {
         "processors": 132,
         "clock_rate": {"base": 1590, "boost": 1980},
         "max_threads_per_processor": 2048,
-        "hourly_rate": 1.34,
+        "hourly_rate": 1.55,
         "graval": {
             "iterations": 3,
             "estimate": 75,
@@ -357,7 +357,7 @@ SUPPORTED_GPUS = {
         "processors": 132,
         "clock_rate": {"base": 1590, "boost": 1980},
         "max_threads_per_processor": 2048,
-        "hourly_rate": 1.25,
+        "hourly_rate": 1.7,
         "graval": {
             "iterations": 5,
             "estimate": 70,
@@ -375,7 +375,7 @@ SUPPORTED_GPUS = {
         "processors": 114,
         "clock_rate": {"base": 1095, "boost": 1755},
         "max_threads_per_processor": 2048,
-        "hourly_rate": 1.25,
+        "hourly_rate": 1.3,
         "graval": {
             "iterations": 3,
             "estimate": 75,
@@ -387,7 +387,7 @@ SUPPORTED_GPUS = {
         "processors": 78,
         "clock_rate": {"base": 1590, "boost": 1980},
         "max_threads_per_processor": 1024,
-        "hourly_rate": 0.5,
+        "hourly_rate": 0.6,
         "graval": {
             "iterations": 1,
             "estimate": 300,
@@ -405,7 +405,7 @@ SUPPORTED_GPUS = {
         "processors": 132,
         "clock_rate": {"base": 1590, "boost": 1980},
         "max_threads_per_processor": 2048,
-        "hourly_rate": 1.9,
+        "hourly_rate": 2.3,
         "graval": {
             "iterations": 3,
             "estimate": 70,
@@ -418,7 +418,7 @@ SUPPORTED_GPUS = {
         "processors": 304,
         "clock_rate": {"base": 1600, "boost": 2100},
         "max_threads_per_processor": 256,
-        "hourly_rate": 1.9,
+        "hourly_rate": 2.1,
         "graval": {
             "iterations": 2,
             "estimate": 75,
@@ -430,7 +430,7 @@ SUPPORTED_GPUS = {
         "processors": 148,
         "clock_rate": {"base": 1590, "boost": 1965},
         "max_threads_per_processor": 1024,
-        "hourly_rate": 3.15,
+        "hourly_rate": 3.5,
         "graval": {
             "iterations": 2,
             "estimate": 75,

--- a/api/instance/schemas.py
+++ b/api/instance/schemas.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     Index,
     Table,
     Numeric,
+    Double,
     UniqueConstraint,
 )
 from typing import Optional
@@ -74,7 +75,9 @@ class Instance(Base):
     last_queried_at = Column(DateTime(timezone=True))
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True))
+    activated_at = Column(DateTime(timezone=True), nullable=True)
     last_verified_at = Column(DateTime(timezone=True))
+    stop_billing_at = Column(DateTime, nullable=True)
     verification_error = Column(String, nullable=True)
     consecutive_failures = Column(Integer, default=0)
     chutes_version = Column(String, nullable=True)
@@ -87,6 +90,12 @@ class Instance(Base):
     )
     cacert = Column(String, nullable=True)
     port_mappings = Column(JSONB, nullable=True)
+
+    # Hourly rate charged to customer, which may differ from the hourly rate of the actual
+    # GPUs used for this instance due to node selector. For example, if a chute supports
+    # both H100 and A100, the user is only charged the A100 rate since the miners *could*
+    # have run it on A100s, regardless of whether or not they did so.
+    hourly_rate = Column(Double, nullable=True)
 
     nodes = relationship("Node", secondary=instance_nodes, back_populates="instance")
     chute = relationship("Chute", back_populates="instances")

--- a/api/invocation/router.py
+++ b/api/invocation/router.py
@@ -334,7 +334,10 @@ async def _invoke(
 
         # Automatically switch to paygo when the quota is exceeded.
         if request_count >= quota:
-            if current_user.balance <= 0 and not request.state.free_invocation:
+            if (
+                current_user.current_balance.effective_balance <= 0
+                and not request.state.free_invocation
+            ):
                 logger.warning(
                     f"Payment required: attempted invocation of {chute.name} "
                     f"from user {current_user.username} [{origin_ip}] with no balance "
@@ -343,7 +346,7 @@ async def _invoke(
                 raise HTTPException(
                     status_code=status.HTTP_402_PAYMENT_REQUIRED,
                     detail=(
-                        f"Quota exceeded and account balance is ${current_user.balance}, "
+                        f"Quota exceeded and account balance is ${current_user.current_balance.effective_balance}, "
                         f"please pay with fiat or send tao to {current_user.payment_address}"
                     ),
                 )

--- a/api/migrations/20250829115200_instance_billing.sql
+++ b/api/migrations/20250829115200_instance_billing.sql
@@ -57,7 +57,7 @@ FOR EACH ROW
 EXECUTE FUNCTION update_balance_on_instance_delete();
 
 -- User balance view, which accounts for both the actual balance and the instances (not yet truly billed).
-CREATE OR REPLACE VIEW user_current_balance AS
+CREATE MATERIALIZED VIEW IF NOT EXISTS user_current_balance AS
 SELECT
     u.user_id,
     u.balance as stored_balance,
@@ -90,6 +90,8 @@ LEFT JOIN chutes c ON c.user_id = u.user_id
 LEFT JOIN instances i ON i.chute_id = c.chute_id
 LEFT JOIN jobs j ON j.instance_id = i.instance_id
 GROUP BY u.user_id, u.balance, u.permissions_bitmask;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_current_balance_user_id ON user_current_balance(user_id);
 
 -- migrate:down
 DROP TRIGGER IF EXISTS trigger_update_balance_on_delete ON instances;

--- a/api/migrations/20250829115200_instance_billing.sql
+++ b/api/migrations/20250829115200_instance_billing.sql
@@ -1,0 +1,96 @@
+-- migrate:up
+CREATE OR REPLACE FUNCTION update_balance_on_instance_delete()
+RETURNS TRIGGER AS $$
+DECLARE
+    v_user_id INTEGER;
+    v_is_public BOOLEAN;
+    v_user_permissions INTEGER;
+    v_has_job BOOLEAN;
+    v_total_cost DECIMAL(10,2);
+    v_hours_used DECIMAL(10,6);
+    v_hour_bucket TIMESTAMP;
+BEGIN
+    -- Get the user_id, public status, and check if instance has a job.
+    SELECT c.user_id, c.public, u.permissions_bitmask,
+           EXISTS(SELECT 1 FROM jobs j WHERE j.instance_id = OLD.instance_id)
+    INTO v_user_id, v_is_public, v_user_permissions, v_has_job
+    FROM chutes c
+    JOIN users u ON u.user_id = c.user_id
+    WHERE c.chute_id = OLD.chute_id;
+
+    -- Skip billing for free users.
+    IF (v_user_permissions & 16) = 16 THEN
+        RETURN OLD;
+    END IF;
+
+    -- Skip billing for non-job instances on public chutes.
+    IF NOT v_has_job AND v_is_public = true THEN
+        RETURN OLD;
+    END IF;
+
+    -- Update the actual user balance table.
+    IF OLD.activated_at IS NOT NULL THEN
+        v_hours_used := EXTRACT(EPOCH FROM (
+            LEAST(COALESCE(OLD.stop_billing_timestamp, NOW()), NOW()) - OLD.activated_at
+        )) / 3600.0;
+        v_total_cost := v_hours_used * OLD.hourly_rate;
+        v_hour_bucket := date_trunc('hour', NOW());
+
+        UPDATE users
+        SET balance = balance - v_total_cost
+        WHERE user_id = v_user_id;
+
+        -- Track the amount in the usage_data table.
+        INSERT INTO usage_data (user_id, bucket, chute_id, amount, count, input_tokens, output_tokens)
+        VALUES (v_user_id::varchar, v_hour_bucket, OLD.chute_id, v_total_cost, 1, 0, 0)
+        ON CONFLICT (user_id, bucket, chute_id)
+        DO UPDATE SET amount = usage_data.amount + EXCLUDED.amount;
+    END IF;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Instance deletion trigger to update balances.
+CREATE TRIGGER trigger_update_balance_on_delete
+BEFORE DELETE ON instances
+FOR EACH ROW
+EXECUTE FUNCTION update_balance_on_instance_delete();
+
+-- User balance view, which accounts for both the actual balance and the instances (not yet truly billed).
+CREATE OR REPLACE VIEW user_current_balance AS
+SELECT
+    u.user_id,
+    u.balance as stored_balance,
+    COALESCE(SUM(
+        CASE
+            WHEN i.activated_at IS NOT NULL
+                AND i.stop_billing_at > NOW()
+                AND (u.permissions_bitmask & 16) != 16
+                AND (j.job_id IS NOT NULL OR c.public = false) THEN
+                EXTRACT(EPOCH FROM (
+                    LEAST(COALESCE(i.stop_billing_at, NOW()), NOW()) - i.activated_at
+                )) / 3600.0 * i.hourly_rate
+            ELSE 0
+        END
+    ), 0) as total_instance_costs,
+    u.balance - COALESCE(SUM(
+        CASE
+            WHEN i.activated_at IS NOT NULL
+                AND i.stop_billing_at > NOW()
+                AND (u.permissions_bitmask & 16) != 16
+                AND (j.job_id IS NOT NULL OR c.public = false) THEN
+                EXTRACT(EPOCH FROM (
+                    LEAST(COALESCE(i.stop_billing_at, NOW()), NOW()) - i.activated_at
+                )) / 3600.0 * i.hourly_rate
+            ELSE 0
+        END
+    ), 0) as effective_balance
+FROM users u
+LEFT JOIN chutes c ON c.user_id = u.user_id
+LEFT JOIN instances i ON i.chute_id = c.chute_id
+LEFT JOIN jobs j ON j.instance_id = i.instance_id
+GROUP BY u.user_id, u.balance, u.permissions_bitmask;
+
+-- migrate:down
+DROP TRIGGER IF EXISTS trigger_update_balance_on_delete ON instances;
+DROP FUNCTION IF EXISTS update_balance_on_instance_delete;

--- a/api/permissions.py
+++ b/api/permissions.py
@@ -55,6 +55,10 @@ class Permissioning:
         bitmask=1 << 10,
         description="Affine admin",
     )
+    public_model_deployment = Role(
+        bitmask=1 << 11,
+        description="Allow deploying models publicly.",
+    )
 
     @classmethod
     def enabled(cls, user, role):

--- a/api/user/response.py
+++ b/api/user/response.py
@@ -39,11 +39,7 @@ class SelfResponse(UserResponse):
     payment_address: str
     developer_payment_address: str
     permissions_bitmask: int
-
-    @computed_field
-    @property
-    def balance(self) -> float:
-        return float(self.current_balance.effective_balance)
+    balance: Optional[float]
 
     @computed_field
     @property
@@ -54,3 +50,6 @@ class SelfResponse(UserResponse):
                 if self.permissions_bitmask & role.bitmask == role.bitmask:
                     permissions.append(role.description)
         return permissions
+
+    class Config:
+        from_attributes = True

--- a/api/user/response.py
+++ b/api/user/response.py
@@ -38,8 +38,12 @@ class SelfResponse(UserResponse):
     coldkey: str
     payment_address: str
     developer_payment_address: str
-    balance: float
     permissions_bitmask: int
+
+    @computed_field
+    @property
+    def balance(self) -> float:
+        return float(self.current_balance.effective_balance)
 
     @computed_field
     @property

--- a/api/user/schemas.py
+++ b/api/user/schemas.py
@@ -293,15 +293,18 @@ class PriceOverride(Base):
                 (
                     await session.execute(
                         select(PriceOverride)
-                        .where(PriceOverride.user_id == user_id)
-                        .where(PriceOverride.chute_id.in_([chute_id, "*"]))
-                        .order_by(case((PriceOverride.chute_id == chute_id, 0), else_=1))
+                        .where(
+                            PriceOverride.user_id.in_([user_id, "*"]),
+                            PriceOverride.chute_id == chute_id,
+                        )
+                        .order_by(case((PriceOverride.user_id == user_id, 0), else_=1))
                         .limit(1)
                     )
                 )
                 .unique()
                 .scalar_one_or_none()
             )
+
             if override is not None:
                 serialized = json.dumps(
                     {

--- a/api/user/schemas.py
+++ b/api/user/schemas.py
@@ -114,7 +114,7 @@ class User(Base):
         primaryjoin="foreign(User.user_id) == remote(UserCurrentBalance.user_id)",
         viewonly=True,
         uselist=False,
-        lazy="select",
+        lazy="joined",
     )
 
     @validates("username")

--- a/api/user/schemas.py
+++ b/api/user/schemas.py
@@ -43,6 +43,15 @@ class AdminUserRequest(BaseModel):
     logo_id: Optional[str] = None
 
 
+class UserCurrentBalance(Base):
+    __tablename__ = "user_current_balance"
+    __table_args__ = {"info": {"is_view": True}}
+    user_id = Column(String, primary_key=True)
+    stored_balance = Column(Double)
+    total_instance_costs = Column(Double)
+    effective_balance = Column(Double)
+
+
 class User(Base):
     __tablename__ = "users"
 
@@ -67,7 +76,7 @@ class User(Base):
     developer_payment_address = Column(String)
     developer_wallet_secret = Column(String)
 
-    # Balance in USD.
+    # Balance in USD (doesn't account for instances still running on private chutes).
     balance = Column(Double, default=0.0)
 
     # Friendly name for the frontend for chute creators
@@ -98,6 +107,15 @@ class User(Base):
     images = relationship("Image", back_populates="user")
     api_keys = relationship("APIKey", back_populates="user", cascade="all, delete-orphan")
     jobs = relationship("Job", back_populates="user")
+
+    # The "true" balance which also accounts for the private instances.
+    current_balance = relationship(
+        "UserCurrentBalance",
+        primaryjoin="User.user_id == UserCurrentBalance.user_id",
+        viewonly=True,
+        uselist=False,
+        lazy="select",
+    )
 
     @validates("username")
     def validate_username(self, _, value):

--- a/api/user/schemas.py
+++ b/api/user/schemas.py
@@ -111,7 +111,7 @@ class User(Base):
     # The "true" balance which also accounts for the private instances.
     current_balance = relationship(
         "UserCurrentBalance",
-        primaryjoin="User.user_id == UserCurrentBalance.user_id",
+        primaryjoin="foreign(User.user_id) == remote(UserCurrentBalance.user_id)",
         viewonly=True,
         uselist=False,
         lazy="select",

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -28,6 +28,12 @@ redis-access: "true"
 db-access: "true"
 {{- end }}
 
+{{- define "balanceRefresher.labels" -}}
+app.kubernetes.io/name: balance-refresher
+redis-access: "true"
+db-access: "true"
+{{- end }}
+
 {{- define "graval.labels" -}}
 app.kubernetes.io/name: graval
 redis-access: "true"

--- a/charts/templates/balance-refresher-cronjob.yaml
+++ b/charts/templates/balance-refresher-cronjob.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: balance-refresher
+  labels:
+    {{- include "balanceRefresher.labels" . | nindent 4 }}
+spec:
+  schedule: "* * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 10
+  failedJobsHistoryLimit: 10
+  activeDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 15000
+      template:
+        metadata:
+          labels:
+            {{- include "balanceRefresher.labels" . | nindent 12 }}
+        spec:
+          restartPolicy: Never
+          {{- with .Values.balanceRefresher.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.balanceRefresher.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.balanceRefresher.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          containers:
+            - name: balance-refresher
+              image: "{{ .Values.balanceRefresher.image }}"
+              imagePullPolicy: {{ .Values.balanceRefresher.imagePullPolicy }}
+              command: ["poetry", "run", "python", "balance_refresher.py"]
+              env:
+                {{- include "chutes.sensitiveEnv" . | nindent 16 }}
+                {{- include "chutes.commonEnv" . | nindent 16 }}
+              resources:
+                {{- toYaml .Values.balanceRefresher.resources | nindent 16 }}

--- a/charts/templates/balance-refresher-cronjob.yaml
+++ b/charts/templates/balance-refresher-cronjob.yaml
@@ -9,11 +9,11 @@ spec:
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 10
   failedJobsHistoryLimit: 10
-  activeDeadlineSeconds: 300
   jobTemplate:
     spec:
       backoffLimit: 2
       ttlSecondsAfterFinished: 15000
+      activeDeadlineSeconds: 300
       template:
         metadata:
           labels:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -445,6 +445,10 @@ failedChuteCleanup:
   nodeSelector:
     kubernetes.io/hostname: chutes-prod-0
 
+balanceRefresher:
+  enabled: true
+  image: parachutes/validator:latest
+
 memcached:
   image: memcached:1.6.34
   imagePullPolicy: IfNotPresent

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -387,7 +387,7 @@ quotaRedis:
     customArgs: []
 
 registry:
-  image: registry:2
+  image: registry:3.0.0-rc.3
   imagePullPolicy: IfNotPresent
   replicaCount: 2
   nodeSelector: {}
@@ -436,18 +436,21 @@ registryProxy:
 auditExporter:
   enabled: true
   image: parachutes/validator:latest
+  imagePullPolicy: Always
   nodeSelector:
     kubernetes.io/hostname: chutes-prod-0
 
 failedChuteCleanup:
   enabled: true
   image: parachutes/validator:latest
+  imagePullPolicy: Always
   nodeSelector:
     kubernetes.io/hostname: chutes-prod-0
 
 balanceRefresher:
   enabled: true
   image: parachutes/validator:latest
+  imagePullPolicy: Always
 
 memcached:
   image: memcached:1.6.34

--- a/watchtower.py
+++ b/watchtower.py
@@ -1521,29 +1521,10 @@ async def slurp(instance, path, offset: int = 0, length: int = 0):
             raise EnvdumpMissing(f"Failed to load and decrypt _eslurp payload: {exc=}")
 
 
-async def report_missing_short_lived_instances():
-    """
-    Continuously report invocations for instances alive less than threshold
-    that didn't get reported from the trigger (in-flight during/after termination timestamp).
-    """
-    while True:
-        logger.info("Reporting short-lived invocations not caught by the trigger.")
-        try:
-            async with get_session() as session:
-                await session.execute(text("SELECT report_missing_short_lived_instances()"))
-        except Exception as exc:
-            logger.warning(f"Failed to execute report_missing_short_lived_instances(): {exc=}")
-        await asyncio.sleep(600)
-
-
 async def main():
     """
     Main loop, continuously check all chutes and instances.
     """
-
-    # Short-lived report cleanup (invocations created after instance deletion date).
-    asyncio.create_task(report_missing_short_lived_instances())
-
     # Rolling update cleanup.
     asyncio.create_task(rolling_update_cleanup())
 


### PR DESCRIPTION
- User-defined chutes can no longer be public, and are billed at the hourly rate.
  - Add max_instances, shutdown_after_seconds, and scaling_threshold to chute definitions to control costs.
- Billing view (as materialized for performance) to track instances that aren't terminated.
- Balance update script which also terminates instances/jobs when user has insufficient balance.
- Price adjustments closer to market rates for hourly
- Increase LLM pricing and improve formula for billing to account for chute concurrency