### PR TITLE
ci: set read-only workflow token permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches-ignore: [main, master]
 
+
+permissions:
+  contents: read
 jobs:
   ruff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- set explicit read-only `GITHUB_TOKEN` permissions for CI workflows that only need repository checkout/read access
- leave release/deploy/write-capable workflows unchanged

## Why
This follows GitHub Actions least-privilege guidance and reduces the default token scope available to routine CI jobs without changing the test/build commands.

## Verification
- Parsed the changed workflow YAML with PyYAML.
- Ran `git diff --check`.
